### PR TITLE
V2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,29 +70,27 @@ const content = userSchema.readContent(partial);
 ## Performances
 
 ```
-[Array] JSON x 84.04 ops/sec ±0.77% (64 runs sampled)
-[Array] Compactr x 88.12 ops/sec ±0.99% (66 runs sampled)
+[Array] JSON x 138 ops/sec ±8.72% (57 runs sampled)
+[Array] Compactr x 112 ops/sec ±9.39% (46 runs sampled)
 
-[Boolean] JSON x 99.29 ops/sec ±0.88% (64 runs sampled)
-[Boolean] Compactr x 190 ops/sec ±1.17% (75 runs sampled)
+[Boolean] JSON x 223 ops/sec ±6.41% (69 runs sampled)
+[Boolean] Compactr x 357 ops/sec ±6.14% (71 runs sampled)
 
-[Float] JSON x 66.76 ops/sec ±1.10% (61 runs sampled)
-[Float] Compactr x 112 ops/sec ±1.67% (70 runs sampled)
+[Float] JSON x 151 ops/sec ±3.15% (75 runs sampled)
+[Float] Compactr x 253 ops/sec ±2.85% (71 runs sampled)
 
-[Integer] JSON x 103 ops/sec ±1.41% (66 runs sampled)
-[Integer] Compactr x 202 ops/sec ±1.74% (74 runs sampled)
+[Integer] JSON x 216 ops/sec ±3.75% (71 runs sampled)
+[Integer] JSON (negative) x 204 ops/sec ±5.35% (65 runs sampled)
+[Integer] Compactr x 401 ops/sec ±5.21% (69 runs sampled)
+[Integer] Compactr (negative) x 406 ops/sec ±3.26% (74 runs sampled)
 
-[Integer (negative)] JSON  x 109 ops/sec ±1.24% (69 runs sampled)
-[Integer (negative)] Compactr  x 203 ops/sec ±1.55% (74 runs sampled)
+[Object] JSON x 123 ops/sec ±4.30% (69 runs sampled)
+[Object] Compactr x 96.77 ops/sec ±2.12% (67 runs sampled)
 
-[Object] JSON x 61.91 ops/sec ±1.32% (58 runs sampled)
-[Object] Compactr x 44.78 ops/sec ±2.19% (54 runs sampled)
-
-[String] JSON x 68.89 ops/sec ±1.48% (63 runs sampled)
-[String] Compactr x 79.16 ops/sec ±2.04% (61 runs sampled)
-
-[String (special characters)] JSON x 71.65 ops/sec ±1.15% (65 runs sampled)
-[String (special characters)] Compactr x 144 ops/sec ±1.37% (71 runs sampled)
+[String] JSON x 136 ops/sec ±4.70% (68 runs sampled)
+[String] JSON special characters x 180 ops/sec ±1.04% (77 runs sampled)
+[String] Compactr x 176 ops/sec ±2.03% (76 runs sampled)
+[String] Compactr special characters x 360 ops/sec ±1.59% (84 runs sampled)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ const buffer = userSchema.bytes();
 
 
 // Decoding (full)
-const content = userSchema.decode(buffer);
+const content = userSchema.read(buffer);
 
 // Decoding (partial)
-const content = userSchema.decode(header, partial);
+const content = userSchema.readContent(partial);
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -70,27 +70,23 @@ const content = userSchema.readContent(partial);
 ## Performances
 
 ```
-[Array] JSON x 138 ops/sec ±8.72% (57 runs sampled)
-[Array] Compactr x 112 ops/sec ±9.39% (46 runs sampled)
+[Array] JSON x 188 ops/sec ±2.47% (73 runs sampled)
+[Array] Compactr x 248 ops/sec ±3.16% (72 runs sampled)
 
-[Boolean] JSON x 223 ops/sec ±6.41% (69 runs sampled)
-[Boolean] Compactr x 357 ops/sec ±6.14% (71 runs sampled)
+[Boolean] JSON x 220 ops/sec ±5.04% (71 runs sampled)
+[Boolean] Compactr x 731 ops/sec ±7.57% (74 runs sampled)
 
-[Float] JSON x 151 ops/sec ±3.15% (75 runs sampled)
-[Float] Compactr x 253 ops/sec ±2.85% (71 runs sampled)
+[Float] JSON x 159 ops/sec ±3.41% (70 runs sampled)
+[Float] Compactr x 476 ops/sec ±1.58% (85 runs sampled)
 
-[Integer] JSON x 216 ops/sec ±3.75% (71 runs sampled)
-[Integer] JSON (negative) x 204 ops/sec ±5.35% (65 runs sampled)
-[Integer] Compactr x 401 ops/sec ±5.21% (69 runs sampled)
-[Integer] Compactr (negative) x 406 ops/sec ±3.26% (74 runs sampled)
+[Integer] JSON x 264 ops/sec ±1.79% (79 runs sampled)
+[Integer] Compactr x 885 ops/sec ±1.36% (84 runs sampled)
 
-[Object] JSON x 123 ops/sec ±4.30% (69 runs sampled)
-[Object] Compactr x 96.77 ops/sec ±2.12% (67 runs sampled)
+[Object] JSON x 139 ops/sec ±1.89% (76 runs sampled)
+[Object] Compactr x 169 ops/sec ±1.52% (80 runs sampled)
 
-[String] JSON x 136 ops/sec ±4.70% (68 runs sampled)
-[String] JSON special characters x 180 ops/sec ±1.04% (77 runs sampled)
-[String] Compactr x 176 ops/sec ±2.03% (76 runs sampled)
-[String] Compactr special characters x 360 ops/sec ±1.59% (84 runs sampled)
+[String] JSON x 107 ops/sec ±6.86% (64 runs sampled)
+[String] Compactr x 167 ops/sec ±4.86% (72 runs sampled)
 ```
 
 

--- a/benchmarks/array.js
+++ b/benchmarks/array.js
@@ -12,7 +12,7 @@ const Compactr = require('../');
 
 let User = Compactr.schema({
   id: { type: 'int32', size: 4 },
-  arr: { type: 'array', items: { type: 'char8' }}
+  arr: { type: 'array', size: 6, items: { type: 'char8', size: 1 }}
 });
 
 const mult = 32;
@@ -39,7 +39,7 @@ function arrCompactr() {
   let packed, unpacked;
 
   for(let i = 0; i<mult*mult; i++) {
-    packed = User.write({ id: i, arr: ['a', 'b', 'c'] }).array();
-    unpacked = User.read(packed);
+    packed = User.write({ id: i, arr: ['a', 'b', 'c'] }).contentArray();
+    unpacked = User.readContent(packed);
   }
 }

--- a/benchmarks/boolean.js
+++ b/benchmarks/boolean.js
@@ -39,7 +39,7 @@ function boolCompactr() {
   let packed, unpacked;
 
   for(let i = 0; i<mult*mult; i++) {
-    packed = User.write({ id: i, bool: !!Math.random() }).array();
-    unpacked = User.read(packed);
+    packed = User.write({ id: i, bool: !!Math.random() }).contentArray();
+    unpacked = User.readContent(packed);
   }
 }

--- a/benchmarks/double.js
+++ b/benchmarks/double.js
@@ -12,7 +12,6 @@ const Compactr = require('../');
 
 let User = Compactr.schema({ 
   id: { type: 'int32', size: 4 }, 
-  str: { type: 'char8', size: 6 }, 
   int: { type: 'double', size: 8 }
 });
 
@@ -40,7 +39,7 @@ function floatCompactr() {
   let packed, unpacked;
 
   for(let i = 0; i<mult*mult; i++) {
-    packed = User.write({ id: i, int: Math.random() }).array();
-    unpacked = User.read(packed);
+    packed = User.write({ id: i, int: Math.random() }).contentArray();
+    unpacked = User.readContent(packed);
   }
 }

--- a/benchmarks/integer.js
+++ b/benchmarks/integer.js
@@ -12,7 +12,6 @@ const Compactr = require('../');
 
 let User = Compactr.schema({ 
   id: { type: 'int32', size: 4 }, 
-  str: { type: 'char8', size: 6 }, 
   int: { type: 'int32', size: 8 }
 });
 
@@ -23,9 +22,7 @@ const intSuite = new Benchmark.Suite();
 /* Float suite ---------------------------------------------------------------*/
 
 intSuite.add('[Integer] JSON', intJSON)
-.add('[Integer] JSON (negative)', negativeIntJSON)
 .add('[Integer] Compactr', intCompactr)
-.add('[Integer] Compactr (negative)', negativeIntCompactr)
 .on('cycle', e => console.log(String(e.target)))
 .run({ 'async': true });
 
@@ -42,25 +39,7 @@ function intCompactr() {
   let packed, unpacked;
 
   for(let i = 0; i<mult*mult; i++) {
-    packed = User.write({ id: i, int: Math.round(Math.random() * 1000000) }).array();
-    unpacked = User.read(packed);
-  }
-}
-
-function negativeIntJSON() {
-  let packed, unpacked;
-
-  for(let i = 0; i<mult*mult; i++) {
-    packed = new Buffer(JSON.stringify({ id: i, int: Math.round(Math.random() * -1000000) }));
-    unpacked = JSON.parse(packed.toString());
-  }
-}
-
-function negativeIntCompactr() {
-  let packed, unpacked;
-
-  for(let i = 0; i<mult*mult; i++) {
-    packed = User.write({ id: i, int: Math.round(Math.random() * -1000000) }).array();
-    unpacked = User.read(packed);
+    packed = User.write({ id: i, int: Math.round(Math.random() * 1000000) }).contentArray();
+    unpacked = User.readContent(packed);
   }
 }

--- a/benchmarks/object.js
+++ b/benchmarks/object.js
@@ -12,7 +12,7 @@ const Compactr = require('../');
 
 let User = Compactr.schema({ 
   id: { type: 'int32', size: 4 }, 
-  obj: { type: 'object', schema: { str: { type: 'string' } } }, 
+  obj: { type: 'object', size: 9, schema: { str: { type: 'string', size: 6 } } }, 
 });
 
 const mult = 32;
@@ -40,7 +40,7 @@ function objCompactr() {
   let packed, unpacked;
 
   for(let i = 0; i<mult*mult; i++) {
-    packed = User.write({ id: i, obj: { str: '' + (Math.random()*0xffffff) } }).array();
-    unpacked = User.read(packed);
+    packed = User.write({ id: i, obj: { str: '' + (Math.random()*0xffffff) } }).contentArray();
+    unpacked = User.readContent(packed);
   }
 }

--- a/benchmarks/string.js
+++ b/benchmarks/string.js
@@ -23,9 +23,7 @@ const stringSuite = new Benchmark.Suite();
 /* Float suite ---------------------------------------------------------------*/
 
 stringSuite.add('[String] JSON', strJSON)
-.add('[String] JSON special characters', strSpecialJSON)
 .add('[String] Compactr', strCompactr)
-.add('[String] Compactr special characters', strSpecialCompactr)
 .on('cycle', e => console.log(String(e.target)))
 .run({ 'async': true });
 
@@ -34,7 +32,7 @@ function strJSON() {
   let packed, unpacked;
 
   for(let i = 0; i<mult*mult; i++) {
-    packed = new Buffer(JSON.stringify({ id: i, str: '' + (Math.random()*0xffffff) }));
+    packed = new Buffer(JSON.stringify({ id: i, str: '' + (Math.random()*0xffffff), special: String.fromCharCode(Math.random()*0xffff) }));
     unpacked = JSON.parse(packed.toString());
   }
 }
@@ -43,25 +41,7 @@ function strCompactr() {
   let packed, unpacked;
 
   for(let i = 0; i<mult*mult; i++) {
-    packed = User.write({ id: i, str: '' + (Math.random()*0xffffff) }).array();
-    unpacked = User.read(packed);
-  }
-}
-
-function strSpecialJSON() {
-  let packed, unpacked;
-
-  for(let i = 0; i<mult*mult; i++) {
-    packed = new Buffer(JSON.stringify({ id: i, special: String.fromCharCode(Math.random()*0xffff) }));
-    unpacked = JSON.parse(packed.toString());
-  }
-}
-
-function strSpecialCompactr() {
-  let packed, unpacked;
-
-  for(let i = 0; i<mult*mult; i++) {
-    packed = User.write({ id: i, special: String.fromCharCode(Math.random()*0xffff) }).array();
-    unpacked = User.read(packed);
+    packed = User.write({ id: i, str: '' + (Math.random()*0xffffff), special: String.fromCharCode(Math.random()*0xffff) }).contentArray();
+    unpacked = User.readContent(packed);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compactr",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Schema based serialization made easy",
   "main": "index.js",
   "scripts": {

--- a/src/reader.js
+++ b/src/reader.js
@@ -11,11 +11,11 @@ const Decoder = require('./decoder');
 function Reader(scope) {
 
   function read(bytes) {
-    readMap(bytes);
-    return readData(bytes);
+    readHeader(bytes);
+    return readContent(bytes);
   }
 
-  function readMap(bytes) {
+  function readHeader(bytes) {
     scope.header.length = 0;
     let caret = 1;
     const keys = bytes[0];
@@ -43,7 +43,7 @@ function Reader(scope) {
     }
   }
 
-  function readData(bytes) {
+  function readContent(bytes) {
     let caret = scope.contentBegins;
     const ret = {};
     for (let i = 0; i < scope.header.length; i++) {
@@ -53,7 +53,7 @@ function Reader(scope) {
     return ret;
   }
 
-  return { read, readMap, readData };
+  return { read, readHeader, readContent };
 }
 
 /* Exports -------------------------------------------------------------------*/

--- a/src/reader.js
+++ b/src/reader.js
@@ -12,11 +12,11 @@ function Reader(scope) {
 
   function read(bytes) {
     readHeader(bytes);
-    return readContent(bytes);
+    return readContent(bytes, scope.contentBegins);
   }
 
   function readHeader(bytes) {
-    scope.header.length = 0;
+    scope.header = [];
     let caret = 1;
     const keys = bytes[0];
     for (let i = 0; i < keys; i++) {
@@ -43,8 +43,8 @@ function Reader(scope) {
     }
   }
 
-  function readContent(bytes) {
-    let caret = scope.contentBegins;
+  function readContent(bytes, caret) {
+    caret = caret || 0;
     const ret = {};
     for (let i = 0; i < scope.header.length; i++) {
       ret[scope.header[i].key.name] = scope.header[i].key.transformOut(bytes.slice(caret, caret + scope.header[i].size));

--- a/src/schema.js
+++ b/src/schema.js
@@ -24,7 +24,11 @@ function Schema(schema) {
     contentBegins: 0
   };
 
+  const writer = Writer(scope);
+  const reader = Reader(scope);
+
   scope.indices = preformat(schema);
+  reader.readHeader(writer.blank()); // Pre-load header for easy streaming
 
   function preformat(schema) {
     const ret = {};
@@ -46,6 +50,8 @@ function Schema(schema) {
           count
         };
       });
+
+
 
     return ret;
   }
@@ -73,7 +79,7 @@ function Schema(schema) {
     return childSchema;
   }
 
-  return Object.assign({}, Writer(scope), Reader(scope));
+  return Object.assign({}, writer, reader);
 }
 
 /* Exports -------------------------------------------------------------------*/

--- a/src/writer.js
+++ b/src/writer.js
@@ -34,8 +34,8 @@ function Writer(scope) {
   }
 
   function clear() {
-    scope.headerBytes.length = 0;
-    scope.contentBytes.length = 0;
+    scope.headerBytes = [0];
+    scope.contentBytes = [];
   }
 
   function filterKeys(data) {
@@ -51,7 +51,17 @@ function Writer(scope) {
     res.push.apply(res, header);
     res.push.apply(res, content);
     return res;
-  } 
+  }
+
+  function blank() {
+    const b = {};
+    for (let i in scope.schema) {
+      b[i] = 1;
+    }
+    write(b, { coerse: true });
+
+    return this;
+  }
 
   function headerBuffer() {
     return Buffer.from(scope.headerBytes);
@@ -77,7 +87,7 @@ function Writer(scope) {
     return concat(scope.headerBytes, scope.contentBytes);
   }
 
-  return { write, headerBuffer, headerArray, contentBuffer, contentArray, buffer, array };
+  return { write, headerBuffer, headerArray, contentBuffer, contentArray, buffer, array, blank };
 }
 
 /* Exports -------------------------------------------------------------------*/

--- a/src/writer.js
+++ b/src/writer.js
@@ -38,6 +38,19 @@ function Writer(scope) {
     scope.contentBytes = [];
   }
 
+  function sizes(data) {
+    const s = {};
+    for (let key in data) {
+      if (data[key] instanceof Object) {
+        s[key] = scope.indices[key].nested.sizes(data[key]);
+        s.size = scope.indices[key].transformIn(data[key]).length;
+      }
+      else s[key] = scope.indices[key].transformIn(data[key]).length;
+    }
+
+    return s;
+  }
+
   function filterKeys(data) {
     const res = [];
     for (let key in data) {
@@ -51,16 +64,6 @@ function Writer(scope) {
     res.push.apply(res, header);
     res.push.apply(res, content);
     return res;
-  }
-
-  function blank() {
-    const b = {};
-    for (let i in scope.schema) {
-      b[i] = 1;
-    }
-    write(b, { coerse: true });
-
-    return this;
   }
 
   function headerBuffer() {
@@ -87,7 +90,7 @@ function Writer(scope) {
     return concat(scope.headerBytes, scope.contentBytes);
   }
 
-  return { write, headerBuffer, headerArray, contentBuffer, contentArray, buffer, array, blank };
+  return { write, headerBuffer, headerArray, contentBuffer, contentArray, buffer, array, sizes };
 }
 
 /* Exports -------------------------------------------------------------------*/

--- a/tests/index.js
+++ b/tests/index.js
@@ -126,3 +126,121 @@ describe('Data integrity - multi mixed', () => {
     });
   });
 });
+
+/* Partial -------------------------------------------------------------------*/
+
+describe('Data integrity - partial - simple', () => {
+  describe('Boolean', () => {
+    const Schema = Compactr.schema({ test: { type: 'boolean' } });
+
+    it('should preserve boolean value and type - true', () => {
+      expect(Schema.readContent(Schema.write({ test: true }).contentArray())).to.deep.equal({ test: true });
+    });
+
+    it('should preserve boolean value and type - false', () => {
+      expect(Schema.readContent(Schema.write({ test: false }).contentArray())).to.deep.equal({ test: false });
+    });
+
+    it('should still send one 0 byte in case of null (coersed)', () => {
+      expect(Schema.readContent(Schema.write({ test: null }).contentArray())).to.deep.equal({ test: false });
+    });
+  });
+
+  describe('Number', () => {
+    const Schema = Compactr.schema({ test: { type: 'number' } });
+
+    it('should preserve number value and type', () => {
+      expect(Schema.readContent(Schema.write({ test: 23.23 }).contentArray())).to.deep.equal({ test: 23.23 });
+    });
+
+    it('should preserve number value and type for negative values', () => {
+      expect(Schema.readContent(Schema.write({ test: -23.23 }).contentArray())).to.deep.equal({ test: -23.23 });
+    });
+  });
+
+  describe('String', () => {
+    const Schema = Compactr.schema({ test: { type: 'string', size: 22 } });
+
+    it('should preserve string value and type', () => {
+      expect(Schema.readContent(Schema.write({ test: 'hello world' }).contentArray())).to.deep.equal({ test: 'hello world' });
+    });
+  });
+
+  describe('Array', () => {
+    const Schema = Compactr.schema({ test: { type: 'array', size: 20, items: { type: 'string' } } });
+
+    it('should preserve array values and types', () => {
+      expect(Schema.readContent(Schema.write({ test: ['a', 'b', 'c'] }).contentArray())).to.deep.equal({ test: ['a', 'b', 'c'] });
+    });
+  });
+
+  describe('Schema', () => {
+    const Schema = Compactr.schema({ test: { type: 'object', size: 20, schema: { test: { type: 'number' } } } });
+
+    it('should preserve object values and types', () => {
+      expect(Schema.readContent(Schema.write({ test: { test: 23.23 } }).contentArray())).to.deep.equal({ test: { test: 23.23 } });
+    });
+  });
+});
+
+describe('Data integrity - partial - multi simple', () => {
+  describe('Booleans', () => {
+    const Schema = Compactr.schema({ test: { type: 'boolean' }, test2: { type: 'boolean' } });
+
+    it('should preserve boolean value and type - false', () => {
+      expect(Schema.readContent(Schema.write({ test: false, test2: true }).contentArray())).to.deep.equal({ test: false, test2: true });
+    });
+
+    it('should skip null or undefined values', () => {
+      expect(Schema.readContent(Schema.write({ test: null, test2: false }).contentArray())).to.deep.equal({ test: false, test2: false });
+    });
+  });
+
+  describe('Numbers', () => {
+    const Schema = Compactr.schema({ test: { type: 'number' }, test2: { type: 'number' } });
+
+    it('should preserve number value and type', () => {
+      expect(Schema.readContent(Schema.write({ test: 23.23, test2: -97.7 }).contentArray())).to.deep.equal({ test: 23.23, test2: -97.7 });
+    });
+  });
+
+  describe('Strings', () => {
+    const Schema = Compactr.schema({ test: { type: 'string', size: 22 }, test2: { type: 'string', size: 8 } });
+
+    it('should preserve string value and type', () => {
+      expect(Schema.readContent(Schema.write({ test: 'hello world', test2: 'écho' }).contentArray())).to.deep.equal({ test: 'hello world', test2: 'écho' });
+    });
+  });
+
+  describe('Arrays', () => {
+    const Schema = Compactr.schema({ test: { type: 'array', size: 9, items: { type: 'string' } }, test2: { type: 'array', size: 9, items: { type: 'string' } } });
+
+    it('should preserve array values and types', () => {
+      expect(Schema.readContent(Schema.write({ test: ['a', 'b', 'c'], test2: ['d', 'e', 'f'] }).contentArray())).to.deep.equal({ test: ['a', 'b', 'c'], test2: ['d', 'e', 'f'] });
+    });
+  });
+
+  describe('Schemas', () => {
+    const Schema = Compactr.schema({ test: { type: 'object', size: 11, schema: { test: { type: 'number' } } }, test2: { type: 'object', size: 11, schema: { test: { type: 'number' } } } });
+
+    it('should preserve object values and types', () => {
+      expect(Schema.readContent(Schema.write({ test: { test: 23.23 }, test2: { test: -97.7 } }).contentArray())).to.deep.equal({ test: { test: 23.23 }, test2: { test: -97.7 } });
+    });
+  });
+});
+
+describe('Data integrity - partial - multi mixed', () => {
+  describe('Boolean + number + string + array + object', () => {
+    const Schema = Compactr.schema({
+      bool: { type: 'boolean' },
+      num: { type: 'number' },
+      str: { type: 'string', size: 22 },
+      arr: { type: 'array', items: { type: 'string' }, size: 9 },
+      obj: { type: 'object', size: 9, schema: { sub: { type: 'string' } } }
+    });
+
+    it('should preserve values and types', () => {
+      expect(Schema.readContent(Schema.write({ bool: true, num: 23.23, str: 'hello world', arr: ['a', 'b', 'c'], obj: { sub: 'way' } }).contentArray())).to.deep.equal({ bool: true, num: 23.23, str: 'hello world', arr: ['a', 'b', 'c'], obj: { sub: 'way' } });
+    });
+  });
+});


### PR DESCRIPTION
Includes:
- `Schema.sizes(payload)` to get the size in bytes of the content
- Applying a blank payload at schema compile time for almost plug and play partial serialization 
- #4 
