### PR TITLE
Added package.json funding property

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "test": "mocha tests/index.js --exit",
     "bench": "node benchmarks/array.js && node benchmarks/boolean.js && node benchmarks/double.js && node benchmarks/integer.js && node benchmarks/object.js && node benchmarks/string.js"
   },
+  "funding": {
+    "type": "Open Collective",
+    "url": "https://opencollective.com/fredericcharette"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/compactr/compactr-js.git"


### PR DESCRIPTION
**npm** just added a new [`npm fund` command](https://blog.npmjs.org/post/188841555980/updates-to-community-docs-more) in it's [v6.13.0](https://github.com/npm/cli/releases/tag/v6.13.0) release as part of the efforts to help out the OSS community.

This PR adds `funding` info to **compactr.js** so that users depending on it can actually retrieve the funding url when they run `npm fund` in their projects.

Note: The funding information will only be available once a new version of the package is published to the npm registry.